### PR TITLE
More reliable MakieOutput

### DIFF
--- a/ext/DynamicGridsMakieExt.jl
+++ b/ext/DynamicGridsMakieExt.jl
@@ -361,7 +361,7 @@ function _add_control_widgets!(
             println(stdout, "resetting time...")
             DG.setrunning!(o, false)
             sleep(0.1)
-            DG.setstoppedframe!(output, val)
+            DG.setstoppedframe!(o, val)
             DG.resume!(o; tstop=last(DG.tspan(o)))
         end
     end

--- a/src/outputs/graphic.jl
+++ b/src/outputs/graphic.jl
@@ -137,7 +137,7 @@ function storeframe!(o::GraphicOutput, data)
     if isstored(o)
         _storeframe!(o, eltype(o), data)
     end
-    if isshowable(o, currentframe(data)) 
+    if isshowable(o, currentframe(data))
         showframe(o, data)
     end
     return nothing
@@ -157,10 +157,23 @@ end
 
 # Additional interface for GraphicOutput
 
-showframe(o::GraphicOutput, data) = showframe(o, proc(data), data)
-showframe(o::GraphicOutput, ::Processor, data) = showframe(map(gridview, grids(data)), o, data)
+function showframe(o::GraphicOutput, data) 
+    showframe(o, proc(data), data)
+end
+function showframe(o::GraphicOutput, ::Processor, data)
+    frame = map(maybe_rebuild_grid, init(o), grids(data))
+    showframe(frame, o, data)
+end
 # Handle NamedTuple for outputs that only accept AbstractArray
 showframe(frame::NamedTuple, o::GraphicOutput, data) = showframe(first(frame), o, data)
+
+function maybe_rebuild_grid(a, b)
+    if a isa AbstractDimArray 
+        b isa AbstractDimArray ? rebuild(a, parent(b)) : rebuild(a, b) 
+    else
+        b
+    end
+end
 
 initalisegraphics(o::GraphicOutput, data) = nothing
 finalisegraphics(o::GraphicOutput, data) = showframe(o, data)


### PR DESCRIPTION
In this PR I'm hoping to fix a bunch of things with the MakieOutput to standardise workflows so things mostly just work.

First, the objects returned as frames should always be the identical typed. This is so that lift works with no bugs.

Second, we should also always rebuild any AbstractDimArray instead of passing a raw grid through to any showframe method.

Possibily, we should just use DimArray everywhere internally... but that has some compilation and complexity overheads. Maybe we can just rewrap them for any GridRule and output where users should actually interacti with the whole array rather than a single cell.
