### PR TITLE
add eltype kw to TransformedOutput

### DIFF
--- a/src/outputs/transformed.jl
+++ b/src/outputs/transformed.jl
@@ -40,7 +40,7 @@ function TransformedOutput(f::Function, init::Union{NamedTuple,AbstractMatrix};
     extent = extent isa Nothing ? Extent(; init=init, tspan, kw...) : extent
     # Define buffers to copy to before applying `f`
     buffer = _replicate_init(init, replicates(extent))
-    f1 = deepcopy(f(buffer))
+    f1 = f(buffer)
     if buffer isa NamedTuple
         map(buffer) do b
             b .= (zero(first(b)),)
@@ -48,12 +48,11 @@ function TransformedOutput(f::Function, init::Union{NamedTuple,AbstractMatrix};
     else
         buffer .= (zero(first(buffer)),)
     end
-    zeroframe = f(buffer)
     # Build simulation frames from the output of `f` for empty frames
     frames = if isnothing(eltype)
-        [deepcopy(zeroframe) for _ in eachindex(tspan)]
+        [deepcopy(f1) for _ in eachindex(tspan)]
     else
-        eltype[deepcopy(zeroframe) for _ in eachindex(tspan)]
+        eltype[deepcopy(f1) for _ in eachindex(tspan)]
     end
     # Set the first frame to the output of `f` for `init`
     frames[1] = f1

--- a/src/outputs/transformed.jl
+++ b/src/outputs/transformed.jl
@@ -29,6 +29,8 @@ mutable struct TransformedOutput{T,F,A<:AbstractVector{T},E,B} <: Output{T,A}
     extent::E
     buffer::B
 end
+TransformedOutput{T}(f::Function, init::Union{NamedTuple,AbstractMatrix}; kw...) where T =
+    TransformedOutput(f, init; kw..., eltype=T)
 function TransformedOutput(f::Function, init::Union{NamedTuple,AbstractMatrix}; 
     extent=nothing, 
     eltype=nothing,

--- a/src/outputs/transformed.jl
+++ b/src/outputs/transformed.jl
@@ -42,7 +42,7 @@ function TransformedOutput(f::Function, init::Union{NamedTuple,AbstractMatrix};
     extent = extent isa Nothing ? Extent(; init=init, tspan, kw...) : extent
     # Define buffers to copy to before applying `f`
     buffer = _replicate_init(init, replicates(extent))
-    f1 = f(buffer)
+    f1 = deepcopy(f(buffer))
     if buffer isa NamedTuple
         map(buffer) do b
             b .= (zero(first(b)),)

--- a/src/outputs/transformed.jl
+++ b/src/outputs/transformed.jl
@@ -51,10 +51,11 @@ function TransformedOutput(f::Function, init::Union{NamedTuple,AbstractMatrix};
         buffer .= (zero(first(buffer)),)
     end
     # Build simulation frames from the output of `f` for empty frames
+    zeroframe = f(buffer)
     frames = if isnothing(eltype)
-        [deepcopy(f1) for _ in eachindex(tspan)]
+        [deepcopy(zeroframe) for _ in eachindex(tspan)]
     else
-        eltype[deepcopy(f1) for _ in eachindex(tspan)]
+        eltype[deepcopy(zeroframe) for _ in eachindex(tspan)]
     end
     # Set the first frame to the output of `f` for `init`
     frames[1] = f1


### PR DESCRIPTION
This PR adds an `eltype` keyword so you can manually set the eltype for `TransformedOutput`. This can help when you want to return mixed types.

This PR also moves the field order so that `f` is first, and `do` notation will work even if you need to manually specify the other fields of the final struct..